### PR TITLE
Fix pending sessions alert metric

### DIFF
--- a/grafana/provisioning/dashboards/SeleniumGridDashboard.json
+++ b/grafana/provisioning/dashboards/SeleniumGridDashboard.json
@@ -177,7 +177,7 @@
       "pluginVersion": "7.3.1",
       "targets": [
         {
-          "expr": "selenium_grid_hub_sessions_backlog",
+          "expr": "selenium_grid_hub_sessionQueueSize",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/prometheus/alert.rules
+++ b/prometheus/alert.rules
@@ -22,7 +22,7 @@ groups:
       description: "Selenium grid http://uiplinfdoc040.ipswich.mgsops.net:4444/ went offline!"
 
   - alert: SeleniumGridPendingSessions
-    expr: selenium_grid_hub_sessions_backlog > 0
+    expr: selenium_grid_hub_sessionQueueSize > 0
     for: 5s
     labels:
       severity: page


### PR DESCRIPTION
## Summary
- update the SeleniumGridPendingSessions alert to track the sessionQueueSize gauge exported by the hub
- align the Grafana queued sessions panel with the corrected metric name so dashboards stay consistent

## Testing
- ⚠️ `docker-compose -f docker-compose.yml up -d prometheus selenium_grid_exporter selenium-hub` *(fails: docker-compose not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca763b3b448322bce8ded9fcf6ac22