### PR TITLE
Update build image and module handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.9.0 AS builder
+FROM golang:1.21 AS builder
 WORKDIR /go/src/github.com/wakeful/selenium_grid_exporter
 COPY . .
-RUN go get -d
-RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w'
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w"
 
 FROM busybox:1.27
 LABEL maintainer "AJ <aj@48k.io>"


### PR DESCRIPTION
## Summary
- update the builder stage to use golang:1.21 and download modules with go mod download
- adjust the build flags to use trimpath and strip symbols while keeping static linux build

## Testing
- docker build . *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7c69bbe48322aab8984eff021b5b