### PR TITLE
Modernize module metadata and logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,20 @@
 module github.com/wakeful/selenium_grid_exporter
 
-go 1.12
+go 1.20
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
-	github.com/prometheus/common v0.6.0
+	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
+	github.com/prometheus/common v0.6.0 // indirect
+	github.com/prometheus/procfs v0.0.3 // indirect
+	github.com/sirupsen/logrus v1.2.0 // indirect
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
+	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 )

--- a/selenium_grid_exporter.go
+++ b/selenium_grid_exporter.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/common/log"
 )
 
 const (
@@ -44,7 +44,7 @@ type hubResponse struct {
 }
 
 func NewExporter(uri string) *Exporter {
-	log.Infoln("Collecting data from:", uri)
+	log.Println("Collecting data from:", uri)
 
 	return &Exporter{
 		URI: uri,
@@ -115,7 +115,7 @@ func (e *Exporter) scrape() {
 	if err != nil {
 		e.up.Set(0)
 
-		log.Errorf("Can't scrape Selenium Grid: %v", err)
+		log.Printf("Can't scrape Selenium Grid: %v", err)
 		return
 	}
 
@@ -125,7 +125,7 @@ func (e *Exporter) scrape() {
 
 	if err := json.Unmarshal(body, &hResponse); err != nil {
 
-		log.Errorf("Can't decode Selenium Grid response: %v", err)
+		log.Printf("Can't decode Selenium Grid response: %v", err)
 		return
 	}
 	e.totalSlots.Set(hResponse.Data.Grid.TotalSlots)
@@ -161,7 +161,7 @@ func (e Exporter) fetch() (output []byte, err error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 
 	//s := string(body)
 	//fmt.Println(s)
@@ -171,7 +171,7 @@ func (e Exporter) fetch() (output []byte, err error) {
 func main() {
 	flag.Parse()
 
-	log.Infoln("Starting selenium_grid_exporter")
+	log.Println("Starting selenium_grid_exporter")
 
 	prometheus.MustRegister(NewExporter(*scrapeURI))
 	prometheus.Unregister(prometheus.NewGoCollector())

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,38 +1,52 @@
 # github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
+## explicit
 github.com/alecthomas/template
 github.com/alecthomas/template/parse
 # github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
+## explicit
 github.com/alecthomas/units
 # github.com/beorn7/perks v1.0.1
+## explicit
 github.com/beorn7/perks/quantile
 # github.com/golang/protobuf v1.3.2
+## explicit
 github.com/golang/protobuf/proto
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
+## explicit
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
+## explicit
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/prometheus/client_golang v1.1.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_golang/prometheus/internal
 # github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
+## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.6.0
+## explicit
 github.com/prometheus/common/log
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/model
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 # github.com/prometheus/procfs v0.0.3
+## explicit
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 # github.com/sirupsen/logrus v1.2.0
+## explicit
 github.com/sirupsen/logrus
 # golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
+## explicit
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3
+## explicit
 golang.org/x/sys/windows
 golang.org/x/sys/windows/svc/eventlog
 golang.org/x/sys/windows/registry
 golang.org/x/sys/unix
 # gopkg.in/alecthomas/kingpin.v2 v2.2.6
+## explicit
 gopkg.in/alecthomas/kingpin.v2


### PR DESCRIPTION
## Summary
- actualiza el fichero go.mod para apuntar a Go 1.20 y declarar explícitamente los módulos vendorizados utilizados
- reemplaza el uso del logger de prometheus/common por el paquete estándar log y usa io.ReadAll
- marca en vendor/modules.txt los módulos requeridos como explícitos para mantener la coherencia con go.mod

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ca8217e18883228bc9ccdef41cb791