### PR TITLE
Fix fetch receiver to avoid copying mutex

### DIFF
--- a/selenium_grid_exporter.go
+++ b/selenium_grid_exporter.go
@@ -134,7 +134,7 @@ func (e *Exporter) scrape() {
 	e.sessionQueueSize.Set(hResponse.Data.Grid.SessionQueueSize)
 }
 
-func (e Exporter) fetch() (output []byte, err error) {
+func (e *Exporter) fetch() (output []byte, err error) {
 
 	url := (e.URI + "/graphql")
 	method := "POST"


### PR DESCRIPTION
## Summary
- update the exporter fetch method to use a pointer receiver so the embedded mutex is not copied

## Testing
- go test -mod=vendor ./...
- go vet -mod=vendor ./...

## Additional Notes
- Unable to update the requested dependencies because the environment blocks outbound access to module proxies and upstream repositories (HTTP 403 responses).


------
https://chatgpt.com/codex/tasks/task_e_68cc22648a688322be5abb3469bc284b