### PR TITLE
Update container base images to latest stable releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w"
 
-FROM busybox:1.27
+FROM busybox:1.36.1
 LABEL maintainer "AJ <aj@48k.io>"
 COPY --from=builder /go/src/github.com/wakeful/selenium_grid_exporter/selenium_grid_exporter .
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,18 @@ Usage of /selenium_grid_exporter:
   - run docker-compose -f docker-compose.yml up
   - open grafana at localhost:3000 (admin/foobar)
   - open Dashboards -> Manage -> Selenium4 Grid monitoring
-  
+
 ```
   ![Screenshot](selenium4_grafana.png)
+
+## Container versions
+
+The example stack uses the following container images:
+
+- Runtime image: `busybox:1.36.1`
+- Selenium Hub and browser nodes: `selenium/hub:4.21.0`, `selenium/node-chrome:4.21.0`, `selenium/node-firefox:4.21.0`, `selenium/node-opera:4.21.0`
+- Prometheus server: `prom/prometheus:v2.53.0`
+- Grafana: `grafana/grafana:11.0.0`
 
 ## Metrics
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   chrome:
-    image: selenium/node-chrome:4.15.0
+    image: selenium/node-chrome:4.21.0
     volumes:
       - /dev/shm:/dev/shm
     depends_on:
@@ -22,7 +22,7 @@ services:
       - "6900:5900"
 
   firefox:
-    image: selenium/node-firefox:4.15.0
+    image: selenium/node-firefox:4.21.0
     volumes:
       - /dev/shm:/dev/shm
     depends_on:
@@ -35,7 +35,7 @@ services:
       - "6901:5900"
 
   opera:
-    image: selenium/node-opera:4.15.0
+    image: selenium/node-opera:4.21.0
     volumes:
       - /dev/shm:/dev/shm
     depends_on:
@@ -48,7 +48,7 @@ services:
       - "6902:5900"
 
   selenium-hub:
-    image: selenium/hub:4.15.0
+    image: selenium/hub:4.21.0
     container_name: selenium-hub
     ports:
       - "4442:4442"
@@ -56,7 +56,7 @@ services:
       - "4444:4444"
 
   prometheus:
-    image: prom/prometheus:v2.51.0
+    image: prom/prometheus:v2.53.0
     volumes:
       - ./prometheus/:/etc/prometheus/
       - prometheus_data:/prometheus
@@ -72,7 +72,7 @@ services:
       - 9090:9090
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:11.0.0
     depends_on:
       - prometheus
     ports:


### PR DESCRIPTION
## Summary
- update the exporter runtime to use the busybox 1.36.1 base image
- refresh Selenium Grid, Prometheus, and Grafana container tags to their latest stable versions
- document the container versions used by the example stack in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc225ee4048322b5d6ebd800084f66