### PR TITLE
Expand gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,51 @@
+# General
+.DS_Store
+Thumbs.db
+*.log
+*.tmp
+
+# Editor directories and files
 .idea/
+.vscode/
+*.swp
+*.swo
+
+# Go build artifacts
 selenium_grid_exporter
+seleniumv4_grid_exporter
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+coverage.out
+*.coverprofile
+
+# Build directories
+bin/
+build/
+dist/
+release/
+out/
+tmp/
+
+# Docker / container runtime data
+prometheus/data/
+alertmanager/data/
+grafana/data/
+grafana/logs/
+grafana/plugins/
+
+# Dependency or package manager caches
+vendor.tmp/
+node_modules/
+
+# Local environment overrides
+.env
+.env.local
+*.local.yaml
+*.local.yml
+*.local.json
+


### PR DESCRIPTION
## Summary
- expand the repository .gitignore to cover common OS cruft, IDE metadata, Go build outputs, container data directories, and local environment overrides.

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68cfbb3001088322aea2646cd73140ae